### PR TITLE
Feat: Sound creation model

### DIFF
--- a/stresstoneApp/modelService/.gitignore
+++ b/stresstoneApp/modelService/.gitignore
@@ -1,0 +1,4 @@
+samples
+__pycache__
+test_result
+musicgen-small

--- a/stresstoneApp/modelService/README.md
+++ b/stresstoneApp/modelService/README.md
@@ -1,0 +1,20 @@
+# Model Service Documentation
+
+## Running Model Service
+- Locally download [Musicgen model](https://huggingface.co/facebook/musicgen-small) and decompress into `musicgen-small` folder
+- Run service.py with `uvicorn service:app --reload` for dev. Service run on `8000` port.
+
+## Dependencies 
+
+Hardware requirements:
+- GPU server
+- Nvidia GPU (4G VRAM or higher) [Running on CUDA, Unified Memory devices (e.g., Apple Silicon etc.) need code changes]
+
+Software requirements:
+- Python 3.9
+- `requirements.txt`
+
+## Reference Manuals
+- Musicgen model [https://huggingface.co/facebook/musicgen-small]
+- Musicgen prompts [https://promptecho.com/musicgen?utm_source=musicgen_prompts]
+- FastAPI [https://fastapi.tiangolo.com/]

--- a/stresstoneApp/modelService/musicgen.py
+++ b/stresstoneApp/modelService/musicgen.py
@@ -1,0 +1,58 @@
+import io
+from tqdm import tqdm
+from transformers import AutoProcessor, MusicgenForConditionalGeneration
+import torch
+import scipy
+
+class MusicGen:
+    def __init__(self):
+        self.device = self._get_device()
+        self.processor = AutoProcessor.from_pretrained('./musicgen-small')
+        self.model = MusicgenForConditionalGeneration.from_pretrained(
+            './musicgen-small').to(self.device)
+
+    def _get_device(self):
+        return "cuda:0" if torch.cuda.is_available() else "cpu"
+
+    def generate_music(self, prompt, length: 256):
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+        inputs = self.processor(
+            text=[prompt],
+            padding=True,
+            return_tensors="pt",
+        ).to(self.device)
+
+        # 256 tokens is 5 seconds of audio
+        audio_values = self.model.generate(
+            **inputs, 
+            max_new_tokens=length
+            )
+        audio_values = audio_values.cpu()
+
+        sampling_rate = self.model.config.audio_encoder.sampling_rate
+        # Create an in-memory binary stream
+        wav_bytes = io.BytesIO()
+        scipy.io.wavfile.write(wav_bytes, rate=sampling_rate, data=audio_values[0, 0].numpy())
+        wav_bytes.seek(0)  # Reset the stream position to the beginning
+
+        return wav_bytes
+
+if __name__ == "__main__":
+    musicgen = MusicGen()
+    tests = [
+        "Lo-Fi for Sleeping & Meditating",
+        "Lo-Fi for Studying",
+        "Tropical House",
+        "New Wave",
+        "Coffee Shop",
+        "Melodic Trap, West Coast",
+        "IDM, Smooth",
+        "Ambient, Dreamy",
+        "Synthwave, Retro",
+    ]
+    for prompt in tqdm(tests):
+        wav_bytes = musicgen.generate_music(prompt, 512)
+        # store wav_bytes in a file
+        with open(f"./samples/{prompt}.wav", "wb") as f:
+            f.write(wav_bytes.getvalue())

--- a/stresstoneApp/modelService/requirements.txt
+++ b/stresstoneApp/modelService/requirements.txt
@@ -1,0 +1,15 @@
+torch==2.3.0
+colorama==0.4.6
+dill==0.39
+platformdirs==4.3.6
+tomli==2.2.1
+packaging==24.2
+transformers==4.49.0
+scipy==1.13.1
+numpy==1.24.1
+fastapi==0.115.8
+uvicorn==0.34.0
+pytest==8.3.4
+jedi==0.18.2
+ujson==5.10.0
+httpx==0.28.1

--- a/stresstoneApp/modelService/service.py
+++ b/stresstoneApp/modelService/service.py
@@ -1,0 +1,42 @@
+import os
+from fastapi.concurrency import asynccontextmanager
+from fastapi.responses import FileResponse
+from typing import Literal
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import io
+from musicgen import MusicGen
+import uvicorn
+from fastapi.responses import StreamingResponse
+
+
+class TextToMusic(BaseModel):
+    text: str
+    length: Literal["test", "short", "medium", "long"]
+
+
+model = MusicGen()
+app = FastAPI()
+
+@app.post("/text_to_music")
+async def text_to_music(text_prompt: TextToMusic):
+    prompt = text_prompt.text
+    length = text_prompt.length
+
+    if length == "short":
+        tokens = 256
+    elif length == "medium":
+        tokens = 512
+    elif length == "long":
+        tokens = 1024
+    elif length == "test":
+        tokens = 64
+    else:
+        raise HTTPException(status_code=400, detail="Invalid length parameter")
+
+    music_stream = model.generate_music(prompt, tokens)
+    if not music_stream:
+        raise HTTPException(status_code=500, detail="Music generation failed")
+
+    # Return the music stream as a response
+    return StreamingResponse(io.BytesIO(music_stream.getbuffer()), media_type="audio/wav")

--- a/stresstoneApp/modelService/test_api.py
+++ b/stresstoneApp/modelService/test_api.py
@@ -1,0 +1,57 @@
+import pytest
+from fastapi.testclient import TestClient
+from service import app
+
+client = TestClient(app)
+
+def test_text_to_music_short():
+    response = client.post(
+        "/text_to_music", json={"text": "Lo-Fi for Studying", "length": "short"})
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert len(response.content) > 0
+    with open(f"./test_result/short.wav", "wb") as f:
+        f.write(response.content)
+
+def test_text_to_music_medium():
+    response = client.post(
+        "/text_to_music", json={"text": "Sea wave", "length": "medium"})
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert len(response.content) > 0
+    with open(f"./test_result/medium.wav", "wb") as f:
+        f.write(response.content)
+
+def test_text_to_music_long():
+    response = client.post(
+        "/text_to_music", json={"text": "Melodic Trap, West Coast", "length": "long"})
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert len(response.content) > 0
+    with open(f"./test_result/long.wav", "wb") as f:
+        f.write(response.content)
+
+def test_text_to_music_test():
+    response = client.post(
+        "/text_to_music", json={"text": "calm", "length": "test"})
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert len(response.content) > 0
+    with open(f"./test_result/test.wav", "wb") as f:
+        f.write(response.content)
+
+# Length of error data type
+def test_text_to_music_invalid_length():
+    response = client.post(
+        "/text_to_music", json={"text": "invalid", "length": 500})
+    assert response.status_code == 422
+
+# No text input
+def test_text_to_music_missing_text():
+    response = client.post("/text_to_music", json={"length": "short"})
+    assert response.status_code == 422
+
+# No length input
+def test_text_to_music_missing_length():
+    response = client.post("/text_to_music", json={"text": "happy"})
+    assert response.status_code == 422


### PR DESCRIPTION
Sound creation model backend. Below are some description/rationale:
- Based on the architecture diagram, sound creation is treated as a "third-party service"-ish application. Thus, it is organized in the modelService folder.
- Implementation in Python FastAPI, API name "/text_to_music" (at service.py file)
- Functionality: Takes input of the prompt and generation length and responds to an audio/wav data chunk.
- The unit test for this API was included using the pytest framework.