### PR TITLE
Feature/sir jishes a lot/implement tone player UI

### DIFF
--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -1,28 +1,116 @@
-import { Toolbar, AppBar, Button } from '@mui/material';
+import { useState, useEffect } from 'react';
+import { Toolbar, AppBar, IconButton, Typography, Slider, Box, LinearProgress, Avatar } from '@mui/material';
+import { PlayArrow, Pause, SkipNext, SkipPrevious, VolumeUp, Shuffle, Repeat } from '@mui/icons-material';
 
 export default function TonePlayer() {
+  const [isShuffle, setIsShuffle] = useState(false);
+  const [isRepeat, setIsRepeat] = useState(false);
+  const [progress, setProgress] = useState(30); // Progress percentage (0-100)
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [volume, setVolume] = useState(30); // Volume state (0-100)
+
+  const handleShuffle = () => setIsShuffle((prev) => !prev);
+  const handleRepeat = () => setIsRepeat((prev) => !prev);
+  const handlePlayPause = () => setIsPlaying((prev) => !prev);
+
+  // Simulating progress update
+  const updateProgress = () => {
+    setProgress((prev) => {
+      const newProgress = prev + 1;
+      return newProgress <= 100 ? newProgress : 0; // Loop progress
+    });
+  };
+
+  // Use an interval to update the progress (simulating song progress)
+  useEffect(() => {
+    const interval = setInterval(updateProgress, 100); // Update every 100ms
+    return () => clearInterval(interval); // Clean up the interval on unmount
+  }, []);
+
+  // Handle volume change from slider
+  const handleVolumeChange = (_: Event, newValue: number | number[]) => {
+    setVolume(newValue as number); // Update the volume state when slider changes
+  };
+
   return (
     <AppBar
       position="fixed"
       sx={{
-        // Appear above sider
         zIndex: (theme) => theme.zIndex.drawer + 1,
         bgcolor: '#fff',
         top: 'auto',
         bottom: 0,
         minHeight: '120px',
+        color: 'black',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '0 16px',
       }}
     >
-      <Toolbar>
-        <div
-          style={{
-            color: 'black',
-          }}
-        >
-          Music player components
-        </div>
-        <Button>Play</Button>
+      <Toolbar sx={{ width: '100%', justifyContent: 'space-between', alignItems: 'center' }}>
+        {/* Left side: Album Cover and Song Title */}
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          {/* Album Cover */}
+          <Avatar
+            alt="Album Cover"
+            src="https://via.placeholder.com/60" // Replace with the actual album cover URL
+            sx={{ width: 60, height: 60, marginRight: 2 }}
+          />
+          {/* Song Title and Artist */}
+          <Box>
+            <Typography variant="h6">Song Title</Typography>
+            <Typography variant="body2">Artist</Typography>
+          </Box>
+        </Box>
+
+        {/* Center: Controls (Play, Pause, Skip, Shuffle, Repeat) */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <IconButton
+            color={isShuffle ? 'primary' : 'inherit'}
+            onClick={handleShuffle}
+          >
+            <Shuffle />
+          </IconButton>
+          <IconButton color="inherit">
+            <SkipPrevious />
+          </IconButton>
+          <IconButton color="inherit" onClick={handlePlayPause}>
+            {isPlaying ? <Pause /> : <PlayArrow />}
+          </IconButton>
+          <IconButton color="inherit">
+            <SkipNext />
+          </IconButton>
+          <IconButton
+            color={isRepeat ? 'primary' : 'inherit'}
+            onClick={handleRepeat}
+          >
+            <Repeat />
+          </IconButton>
+        </Box>
+
+        {/* Right side: Volume Slider */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <VolumeUp />
+          <Slider
+            value={volume}
+            onChange={handleVolumeChange} // Update volume on change
+            aria-labelledby="volume-slider"
+            min={0}
+            max={100}
+            sx={{ width: 100 }}
+          />
+        </Box>
       </Toolbar>
+
+      {/* Progress Bar */}
+      <Box sx={{ width: '70%', padding: '0 16px' }}>
+        <LinearProgress
+          variant="determinate"
+          // value={progress}
+          sx={{ height: 5, bgcolor: '#ddd', borderRadius: 2 }}
+        />
+      </Box>
     </AppBar>
   );
 }

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -104,7 +104,7 @@ export default function TonePlayer() {
       </Toolbar>
 
       {/* Progress Bar */}
-      <Box sx={{ width: '70%', padding: '0 16px' }}>
+      <Box sx={{ width: '50%', padding: '0 16px' }}>
         <LinearProgress
           variant="determinate"
           // value={progress}

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -1,35 +1,47 @@
 import { useState, useEffect } from 'react';
 import { Toolbar, AppBar, IconButton, Typography, Slider, Box, LinearProgress, Avatar } from '@mui/material';
-import { PlayArrow, Pause, SkipNext, SkipPrevious, VolumeUp, Shuffle, Repeat } from '@mui/icons-material';
+import { 
+  PlayArrow, 
+  Pause, 
+  SkipNext, 
+  SkipPrevious, 
+  VolumeUp, 
+  Shuffle, 
+  Repeat,
+  ExpandLess,
+  ExpandMore
+} from '@mui/icons-material';
 
 export default function TonePlayer() {
   const [isShuffle, setIsShuffle] = useState(false);
   const [isRepeat, setIsRepeat] = useState(false);
-  const [progress, setProgress] = useState(30); // Progress percentage (0-100)
+  const [progress, setProgress] = useState(30);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [volume, setVolume] = useState(30); // Volume state (0-100)
+  const [volume, setVolume] = useState(30);
+  const [isExpanded, setIsExpanded] = useState(true);
 
   const handleShuffle = () => setIsShuffle((prev) => !prev);
   const handleRepeat = () => setIsRepeat((prev) => !prev);
   const handlePlayPause = () => setIsPlaying((prev) => !prev);
+  const handleToggleExpand = () => setIsExpanded((prev) => !prev);
 
-  // Simulating progress update
   const updateProgress = () => {
     setProgress((prev) => {
       const newProgress = prev + 1;
-      return newProgress <= 100 ? newProgress : 0; // Loop progress
+      return newProgress <= 100 ? newProgress : 0;
     });
   };
 
-  // Use an interval to update the progress (simulating song progress)
   useEffect(() => {
-    const interval = setInterval(updateProgress, 100); // Update every 100ms
-    return () => clearInterval(interval); // Clean up the interval on unmount
-  }, []);
+    let interval: number;
+    if (isPlaying) {
+      interval = setInterval(updateProgress, 100);
+    }
+    return () => clearInterval(interval);
+  }, [isPlaying]);
 
-  // Handle volume change from slider
-  const handleVolumeChange = (_: Event, newValue: number | number[]) => {
-    setVolume(newValue as number); // Update the volume state when slider changes
+  const handleVolumeChange = (_: Event, newValue: number) => {
+    setVolume(newValue);
   };
 
   return (
@@ -40,74 +52,123 @@ export default function TonePlayer() {
         bgcolor: '#fff',
         top: 'auto',
         bottom: 0,
-        minHeight: '120px',
+        minHeight: isExpanded ? '120px' : '64px',
         color: 'black',
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
         padding: '0 16px',
+        transition: 'min-height 0.3s ease-in-out',
       }}
     >
-      <Toolbar sx={{ width: '100%', justifyContent: 'space-between', alignItems: 'center' }}>
+      {/* Collapse/Expand Button */}
+      <IconButton
+        onClick={handleToggleExpand}
+        sx={{
+          position: 'absolute',
+          top: -28,
+          right: 16,
+          bgcolor: 'white',
+          boxShadow: '0 0 8px rgba(0,0,0,0.2)',
+          '&:hover': {
+            bgcolor: 'white',
+          }
+        }}
+      >
+        {isExpanded ? <ExpandMore /> : <ExpandLess />}
+      </IconButton>
+
+      <Toolbar 
+        sx={{ 
+          width: '100%', 
+          justifyContent: 'space-between', 
+          alignItems: 'center',
+          height: isExpanded ? 'auto' : '64px',
+          overflow: 'hidden'
+        }}
+      >
         {/* Left side: Album Cover and Song Title */}
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          {/* Album Cover */}
+        <Box sx={{ 
+          display: 'flex', 
+          alignItems: 'center',
+          width: isExpanded ? 'auto' : '33%'
+        }}>
           <Avatar
             alt="Album Cover"
-            src="https://via.placeholder.com/60" // Replace with the actual album cover URL
-            sx={{ width: 60, height: 60, marginRight: 2 }}
+            src="https://via.placeholder.com/60"
+            sx={{ 
+              width: isExpanded ? 60 : 40, 
+              height: isExpanded ? 60 : 40, 
+              marginRight: 2,
+              transition: 'all 0.3s ease-in-out'
+            }}
           />
-          {/* Song Title and Artist */}
           <Box>
-            <Typography variant="h6">Song Title</Typography>
-            <Typography variant="body2">Artist</Typography>
+            <Typography variant={isExpanded ? "h6" : "body1"}>Song Title</Typography>
+            {isExpanded && <Typography variant="body2">Artist</Typography>}
           </Box>
         </Box>
 
-        {/* Center: Controls (Play, Pause, Skip, Shuffle, Repeat) */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <IconButton
-            color={isShuffle ? 'primary' : 'inherit'}
-            onClick={handleShuffle}
-          >
-            <Shuffle />
-          </IconButton>
-          <IconButton color="inherit">
-            <SkipPrevious />
-          </IconButton>
+        {/* Center: Controls */}
+        <Box sx={{ 
+          display: 'flex', 
+          alignItems: 'center', 
+          gap: 2,
+          width: isExpanded ? 'auto' : '33%',
+          justifyContent: 'center'
+        }}>
+          {isExpanded && (
+            <>
+              <IconButton color={isShuffle ? 'primary' : 'inherit'} onClick={handleShuffle}>
+                <Shuffle />
+              </IconButton>
+              <IconButton color="inherit">
+                <SkipPrevious />
+              </IconButton>
+            </>
+          )}
           <IconButton color="inherit" onClick={handlePlayPause}>
             {isPlaying ? <Pause /> : <PlayArrow />}
           </IconButton>
-          <IconButton color="inherit">
-            <SkipNext />
-          </IconButton>
-          <IconButton
-            color={isRepeat ? 'primary' : 'inherit'}
-            onClick={handleRepeat}
-          >
-            <Repeat />
-          </IconButton>
+          {isExpanded && (
+            <>
+              <IconButton color="inherit">
+                <SkipNext />
+              </IconButton>
+              <IconButton color={isRepeat ? 'primary' : 'inherit'} onClick={handleRepeat}>
+                <Repeat />
+              </IconButton>
+            </>
+          )}
         </Box>
 
         {/* Right side: Volume Slider */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <VolumeUp />
-          <Slider
-            value={volume}
-            onChange={handleVolumeChange} // Update volume on change
-            aria-labelledby="volume-slider"
-            min={0}
-            max={100}
-            sx={{ width: 100 }}
-          />
-        </Box>
+        {isExpanded && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <VolumeUp />
+            <Slider
+              value={volume}
+              onChange={handleVolumeChange}
+              aria-labelledby="volume-slider"
+              min={0}
+              max={100}
+              sx={{ width: 100 }}
+            />
+          </Box>
+        )}
       </Toolbar>
 
       {/* Progress Bar */}
-      <Box sx={{ width: '50%', padding: '0 16px' }}>
+      <Box sx={{ 
+        width: '50%', 
+        padding: '0 16px',
+        opacity: isExpanded ? 1 : 0,
+        transition: 'opacity 0.3s ease-in-out',
+        height: isExpanded ? 'auto' : 0
+      }}>
         <LinearProgress
           variant="determinate"
-          // value={progress}
+          value={progress}
           sx={{ height: 5, bgcolor: '#ddd', borderRadius: 2 }}
         />
       </Box>


### PR DESCRIPTION
Music player in the footer now displays song name and artist, along with controls
<img width="1492" alt="Screenshot 2025-02-22 at 19 20 46" src="https://github.com/user-attachments/assets/911f087f-b76d-44ba-bc3f-499d319ac2a3" />

Play/Pause button controls the dummy song progress bar. 
<img width="1491" alt="Screenshot 2025-02-22 at 19 22 56" src="https://github.com/user-attachments/assets/c615f79a-c39c-4b0c-8989-4e5ff6ba27d6" />
<img width="1489" alt="Screenshot 2025-02-22 at 19 23 10" src="https://github.com/user-attachments/assets/2d0bf7b0-0644-42c3-8236-2337b795f2e2" />

Music player is collapsible
<img width="1490" alt="Screenshot 2025-02-22 at 19 24 45" src="https://github.com/user-attachments/assets/bc5c4e29-7c27-4fd2-b096-c204b73e0525" />