### PR TITLE
Fix/SirJishesALot/music player

### DIFF
--- a/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
+++ b/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef} from 'react';
 import { Box, Typography, Slider, CircularProgress, LinearProgress } from '@mui/material';
 
 interface AudioProgressTrackerProps {

--- a/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
+++ b/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
@@ -229,10 +229,10 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
                 //     boxShadow: `0px 0px 0px 8px ${'rgb(255 255 255 / 16%)'}`,
                 //   }),
                 // },
-                '&.Mui-active': {
-                  height: 20,
-                  width: 20,
-                },
+                // '&.Mui-active': {
+                //   height: 20,
+                //   width: 20,
+                // },
               },
               '& .MuiSlider-rail': {
                 background: `linear-gradient(to right, rgba(0,0,0,0.87) ${getProgressPercentage()}%, #ddd ${getProgressPercentage()}%)`,

--- a/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
+++ b/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
@@ -5,6 +5,7 @@ interface AudioProgressTrackerProps {
   audioData: ArrayBuffer | null;
   isPlaying: boolean;
   isLooping: boolean;
+  volume: number;
   isExpanded: boolean;
   onProgressChange?: (progress: number) => void;
   onPlayStateChange?: (isPlaying: boolean) => void;
@@ -14,6 +15,7 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
   audioData,
   isPlaying = false,
   isLooping = false,
+  volume, 
   isExpanded = false,
   onProgressChange,
   onPlayStateChange,
@@ -85,7 +87,7 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
   useEffect(() => {
     if (audioRef.current) {
       if (isPlaying) {
-        audioRef.current.currentTime = currentTime; // Explicitly set current time
+        audioRef.current.currentTime = currentTime; 
         audioRef.current.play();
         startUpdatingProgress();
       } else {
@@ -94,6 +96,12 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
       }
     }
   }, [isPlaying]);
+
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.volume = (volume / 100);
+    }
+  }, [volume]);
 
   const startUpdatingProgress = () => {
     const update = () => {

--- a/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
+++ b/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
@@ -10,6 +10,7 @@ interface AudioProgressTrackerProps {
   audioData: ArrayBuffer | null; // WAV file data from backend
   isPlaying: boolean,
   isLooping: boolean;
+  isExpanded: boolean;
   onProgressChange?: (progress: number) => void;
   onPlayStateChange?: (isPlaying: boolean) => void;
 }
@@ -18,6 +19,7 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
   audioData,
   isPlaying = false,
   isLooping = false,
+  isExpanded = false,
   onProgressChange,
   onPlayStateChange,
 }) => {
@@ -222,42 +224,44 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
           </IconButton>
         )}
       </Box> */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1 }}>
-        <Slider
-          value={(currentTime / duration) * 100}
-          onChange={handleSeek}
-          aria-label="audio progress"
-          disabled={!isLoaded}
-          sx={(t) => ({
-            color: 'rgba(0,0,0,0.87)',
-            height: 4,
-            '& .MuiSlider-thumb': {
-              width: 8,
-              height: 8,
-              transition: '0.3s cubic-bezier(.47,1.64,.41,.8)',
-              '&::before': {
-                boxShadow: '0 2px 12px 0 rgba(0,0,0,0.4)',
+      {isExpanded && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1, }}>
+          <Slider
+            value={(currentTime / duration) * 100}
+            onChange={handleSeek}
+            aria-label="audio progress"
+            disabled={!isLoaded}
+            sx={(t) => ({
+              color: 'rgba(0,0,0,0.87)',
+              height: 4,
+              '& .MuiSlider-thumb': {
+                width: 8,
+                height: 8,
+                transition: '0.3s cubic-bezier(.47,1.64,.41,.8)',
+                '&::before': {
+                  boxShadow: '0 2px 12px 0 rgba(0,0,0,0.4)',
+                },
+                '&:hover, &.Mui-focusVisible': {
+                  boxShadow: `0px 0px 0px 8px ${'rgb(0 0 0 / 16%)'}`,
+                  ...t.applyStyles('dark', {
+                    boxShadow: `0px 0px 0px 8px ${'rgb(255 255 255 / 16%)'}`,
+                  }),
+                },
+                '&.Mui-active': {
+                  width: 20,
+                  height: 20,
+                },
               },
-              '&:hover, &.Mui-focusVisible': {
-                boxShadow: `0px 0px 0px 8px ${'rgb(0 0 0 / 16%)'}`,
-                ...t.applyStyles('dark', {
-                  boxShadow: `0px 0px 0px 8px ${'rgb(255 255 255 / 16%)'}`,
-                }),
+              '& .MuiSlider-rail': {
+                opacity: 0.28,
               },
-              '&.Mui-active': {
-                width: 20,
-                height: 20,
-              },
-            },
-            '& .MuiSlider-rail': {
-              opacity: 0.28,
-            },
-          })}
-        />
-        {/* <Typography variant="caption" color="text.secondary">
-          {formatTime(currentTime)} / {formatTime(duration)}
-        </Typography> */}
-      </Box>
+            })}
+          />
+          {/* <Typography variant="caption" color="text.secondary">
+            {formatTime(currentTime)} / {formatTime(duration)}
+          </Typography> */}
+        </Box>
+      )}
     </>
   );
 };

--- a/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
+++ b/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
@@ -1,14 +1,9 @@
-import React, { useState, useEffect, useRef } from 'react';
-import {
-  Box,
-  Typography,
-  Slider,
-  CircularProgress,
-} from '@mui/material';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Box, Typography, Slider, CircularProgress, LinearProgress } from '@mui/material';
 
 interface AudioProgressTrackerProps {
-  audioData: ArrayBuffer | null; // WAV file data from backend
-  isPlaying: boolean,
+  audioData: ArrayBuffer | null;
+  isPlaying: boolean;
   isLooping: boolean;
   isExpanded: boolean;
   onProgressChange?: (progress: number) => void;
@@ -23,20 +18,18 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
   onProgressChange,
   onPlayStateChange,
 }) => {
-  // Refs
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const audioContextRef = useRef<AudioContext | null>(null);
   const audioSourceRef = useRef<string | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
 
-  // State
   const [duration, setDuration] = useState<number>(0);
   const [currentTime, setCurrentTime] = useState<number>(0);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isSeeking, setIsSeeking] = useState<boolean>(false); // Track if user is seeking
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // Clean up previous blob URL if it exists
     if (audioSourceRef.current) {
       URL.revokeObjectURL(audioSourceRef.current);
       audioSourceRef.current = null;
@@ -49,13 +42,10 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
 
     try {
       setIsLoading(true);
-
-      // Create blob from ArrayBuffer
       const blob = new Blob([audioData], { type: 'audio/wav' });
       const blobUrl = URL.createObjectURL(blob);
       audioSourceRef.current = blobUrl;
 
-      // Initialize or reset audio element
       if (audioRef.current) {
         audioRef.current.pause();
         audioRef.current.src = blobUrl;
@@ -63,9 +53,7 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
       } else {
         const audio = new Audio(blobUrl);
         audioRef.current = audio;
-        // Set up event listeners
         audio.addEventListener('loadedmetadata', handleLoadedMetadata);
-        audio.addEventListener('timeupdate', handleTimeUpdate);
         audio.addEventListener('ended', handleEnded);
         audio.addEventListener('error', handleError);
       }
@@ -78,23 +66,16 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
       setIsLoaded(true);
     }
 
-    // Clean up
     return () => {
       if (audioRef.current) {
         audioRef.current.pause();
       }
-
       if (audioSourceRef.current) {
         URL.revokeObjectURL(audioSourceRef.current);
-      }
-
-      if (audioContextRef.current) {
-        audioContextRef.current.close();
       }
     };
   }, [audioData]);
 
-  // Update audio loop setting when isLooping changes
   useEffect(() => {
     if (audioRef.current) {
       audioRef.current.loop = isLooping;
@@ -102,43 +83,41 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
   }, [isLooping]);
 
   useEffect(() => {
-    if (!audioContextRef.current) {
-      audioContextRef.current = new (window.AudioContext ||
-        (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext)();
-    }
-
     if (audioRef.current) {
       if (isPlaying) {
+        audioRef.current.currentTime = currentTime; // Explicitly set current time
         audioRef.current.play();
+        startUpdatingProgress();
       } else {
         audioRef.current.pause();
+        cancelAnimationFrame(animationFrameRef.current as number);
       }
     }
   }, [isPlaying]);
 
-  // Handle metadata loaded
+  const startUpdatingProgress = () => {
+    const update = () => {
+      if (audioRef.current && !isSeeking) {
+        setCurrentTime(audioRef.current.currentTime);
+        if (onProgressChange) {
+          onProgressChange((audioRef.current.currentTime / duration) * 100);
+        }
+      }
+      animationFrameRef.current = requestAnimationFrame(update);
+    };
+    cancelAnimationFrame(animationFrameRef.current as number); 
+    animationFrameRef.current = requestAnimationFrame(update);
+  };
+
   const handleLoadedMetadata = () => {
     if (audioRef.current) {
       setDuration(audioRef.current.duration);
+      setCurrentTime(0);
       setIsLoaded(true);
       setIsLoading(false);
     }
   };
 
-  // Handle time update
-  const handleTimeUpdate = () => {
-    if (audioRef.current) {
-      setCurrentTime(audioRef.current.currentTime);
-
-      // Calculate progress percentage
-      const progressPercent = (audioRef.current.currentTime / audioRef.current.duration) * 100;
-      if (onProgressChange) {
-        onProgressChange(progressPercent);
-      }
-    }
-  };
-
-  // Handle end of audio
   const handleEnded = () => {
     if (!isLooping) {
       audioRef.current?.pause();
@@ -148,7 +127,6 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
     }
   };
 
-  // Handle audio loading error
   const handleError = (e: Event) => {
     console.error('Audio loading error:', e);
     setError('Failed to load audio');
@@ -156,23 +134,32 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
     setIsLoaded(false);
   };
 
-  // Format time for display
+  const handleSeekStart = () => {
+    setIsSeeking(true);
+  };
+
+  const handleSeek = (_event: Event, newValue: number | number[]) => {
+    const seekTime = ((newValue as number) / 100) * duration;
+    setCurrentTime(seekTime);
+  };
+
+  const handleSeekEnd = (_event: React.SyntheticEvent | Event, newValue: number | number[]) => {
+    setIsSeeking(false);
+    if (audioRef.current) {
+      audioRef.current.currentTime = ((newValue as number) / 100) * duration;
+    }
+  };
+
   const formatTime = (timeInSeconds: number): string => {
     const minutes = Math.floor(timeInSeconds / 60);
     const seconds = Math.floor(timeInSeconds % 60);
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
   };
 
-  // Handle seek
-  const handleSeek = (event: Event, newValue: number | number[]) => {
-    const seekTo = ((newValue as number) / 100) * duration;
-    if (audioRef.current) {
-      audioRef.current.currentTime = seekTo;
-      setCurrentTime(seekTo);
-    }
+  const getProgressPercentage = () => {
+    return (currentTime / duration) * 100;
   };
 
-  // Loading state
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', p: 2 }}>
@@ -184,7 +171,6 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
     );
   }
 
-  // Error state
   if (error) {
     return (
       <Box sx={{ p: 2, color: 'error.main' }}>
@@ -193,7 +179,6 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
     );
   }
 
-  // No audio data
   if (!audioData) {
     return (
       <Box sx={{ p: 2 }}>
@@ -206,65 +191,53 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
 
   return (
     <>
-      {/* <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 2,
-          width: 'auto',
-          justifyContent: 'center',
-        }}
-      >
-        <IconButton onClick={togglePlay} color="inherit" disabled={!isLoaded}>
-          {isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
-        </IconButton>
-        {showLoopControl && (
-          <IconButton onClick={toggleLoop} color={isLooping ? 'primary' : 'default'} size="small">
-            <Repeat />
-          </IconButton>
-        )}
-      </Box> */}
       {isExpanded && (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1, }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1 }}>
           <Typography variant="body2" color="text.secondary">
             {formatTime(currentTime)}
           </Typography>
           <Slider
-            value={(currentTime / duration) * 100}
+            value={duration > 0 && !isNaN(currentTime) ? getProgressPercentage() : 0}
             onChange={handleSeek}
+            onChangeCommitted={handleSeekEnd}
+            onMouseDown={handleSeekStart}
             aria-label="audio progress"
             disabled={!isLoaded}
-            sx={(t) => ({
-              color: 'rgba(0,0,0,0.87)',
+            track={false}
+            sx={{
+              width: '100%',
               height: 4,
+              color: 'rgba(0,0,0,0.87)',
               '& .MuiSlider-thumb': {
-                width: 8,
-                height: 8,
-                transition: '0.3s cubic-bezier(.47,1.64,.41,.8)',
+                width: 10,
+                height: 10,
+                transition: 'width 0.2s ease-in-out',
                 '&::before': {
                   boxShadow: '0 2px 12px 0 rgba(0,0,0,0.4)',
                 },
-                '&:hover, &.Mui-focusVisible': {
-                  boxShadow: `0px 0px 0px 8px ${'rgb(0 0 0 / 16%)'}`,
-                  ...t.applyStyles('dark', {
-                    boxShadow: `0px 0px 0px 8px ${'rgb(255 255 255 / 16%)'}`,
-                  }),
-                },
+                // '&:hover, &.Mui-focusVisible': {
+                //   boxShadow: `0px 0px 0px 8px ${'rgb(0 0 0 / 16%)'}`,
+                //   ...t.applyStyles('dark', {
+                //     boxShadow: `0px 0px 0px 8px ${'rgb(255 255 255 / 16%)'}`,
+                //   }),
+                // },
                 '&.Mui-active': {
-                  width: 20,
                   height: 20,
+                  width: 20,
                 },
               },
               '& .MuiSlider-rail': {
-                opacity: 0.28,
+                background: `linear-gradient(to right, rgba(0,0,0,0.87) ${getProgressPercentage()}%, #ddd ${getProgressPercentage()}%)`,
+                opacity: 1,
               },
-            })}
+            }}
           />
           <Typography variant="body2" color="text.secondary">
             {formatTime(duration)}
           </Typography>
         </Box>
       )}
+      {!isLoaded && <LinearProgress sx={{ width: '100%', mt: 1 }} />}
     </>
   );
 };

--- a/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
+++ b/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
@@ -226,6 +226,9 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
       </Box> */}
       {isExpanded && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1, }}>
+          <Typography variant="body2" color="text.secondary">
+            {formatTime(currentTime)}
+          </Typography>
           <Slider
             value={(currentTime / duration) * 100}
             onChange={handleSeek}
@@ -257,9 +260,9 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
               },
             })}
           />
-          {/* <Typography variant="caption" color="text.secondary">
-            {formatTime(currentTime)} / {formatTime(duration)}
-          </Typography> */}
+          <Typography variant="body2" color="text.secondary">
+            {formatTime(duration)}
+          </Typography>
         </Box>
       )}
     </>

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -172,18 +172,6 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
       </Toolbar>
 
       {/* Progress Bar */}
-      {/* {isExpanded && (
-        <Box sx={{ width: '50%', padding: '0 16px' }}>
-          <AudioProgressTracker
-            audioData={audioData}
-            isPlaying={isPlaying}
-            isLooping={isRepeat}
-            isExpanded={isExpanded}
-            onPlayStateChange={handlePlayEnd}
-          />
-        </Box>
-      )}  */}
-
       <Box sx={{ width: '50%', padding: '0 16px' }}>
         <AudioProgressTracker
           audioData={audioData}

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -172,16 +172,27 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
       </Toolbar>
 
       {/* Progress Bar */}
-      {isExpanded && (
+      {/* {isExpanded && (
         <Box sx={{ width: '50%', padding: '0 16px' }}>
           <AudioProgressTracker
             audioData={audioData}
             isPlaying={isPlaying}
             isLooping={isRepeat}
+            isExpanded={isExpanded}
             onPlayStateChange={handlePlayEnd}
           />
         </Box>
-      )}
+      )}  */}
+
+      <Box sx={{ width: '50%', padding: '0 16px' }}>
+        <AudioProgressTracker
+          audioData={audioData}
+          isPlaying={isPlaying}
+          isLooping={isRepeat}
+          isExpanded={isExpanded}
+          onPlayStateChange={handlePlayEnd}
+        />
+      </Box>  
     </AppBar>
   );
 }

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -156,6 +156,7 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
               <VolumeUp />
               <Slider
                 value={volume}
+                track={false}
                 onChange={handleVolumeChange}
                 aria-labelledby="volume-slider"
                 min={0}
@@ -163,6 +164,14 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
                 sx={{
                   width: 100,
                   color: 'rgba(0,0,0,0.87)',
+                  '& .MuiSlider-thumb': {
+                    width: 10,
+                    height: 10,
+                  },
+                  '& .MuiSlider-rail': {
+                    background: `linear-gradient(to right, rgba(0,0,0,0.87) ${volume}%, #ddd ${volume}%)`,
+                    opacity: 1,
+                  },
                 }}
               />
             </>

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Toolbar, AppBar, IconButton, Typography, Slider, Box, Avatar } from '@mui/material';
+import { Toolbar, AppBar, IconButton, Typography, Slider, Box, LinearProgress, Avatar } from '@mui/material';
 import { 
   PlayArrow, 
   Pause, 
@@ -172,6 +172,18 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
       </Toolbar>
 
       {/* Progress Bar */}
+      {/* {isExpanded && (
+        <Box sx={{ width: '50%', padding: '0 16px' }}>
+          <AudioProgressTracker
+            audioData={audioData}
+            isPlaying={isPlaying}
+            isLooping={isRepeat}
+            isExpanded={isExpanded}
+            onPlayStateChange={handlePlayEnd}
+          />
+        </Box>
+      )}  */}
+
       <Box sx={{ width: '50%', padding: '0 16px' }}>
         <AudioProgressTracker
           audioData={audioData}

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -36,7 +36,7 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
     onHeightChange(isExpanded ? 120 : 64); // Update parent with the new height
   }, [isExpanded, onHeightChange]);
 
-  const handleVolumeChange = (_: Event, newValue: number | number[]) => {
+  const handleVolumeChange = (_event: Event, newValue: number | number[]) => {
     setVolume(newValue as number);
   };
 
@@ -180,6 +180,7 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
           audioData={audioData}
           isPlaying={isPlaying}
           isLooping={isRepeat}
+          volume = {volume}
           isExpanded={isExpanded}
           onPlayStateChange={handlePlayEnd}
         />

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Toolbar, AppBar, IconButton, Typography, Slider, Box, Avatar } from '@mui/material';
+import { Toolbar, AppBar, IconButton, Typography, Slider, Box, Avatar, Tooltip } from '@mui/material';
 import { 
   PlayArrow, 
   Pause, 
@@ -126,25 +126,35 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
         >
           {isExpanded && (
             <>
-              <IconButton color={isShuffle ? 'primary' : 'inherit'} onClick={handleShuffle}>
-                <Shuffle />
-              </IconButton>
-              <IconButton color="inherit">
-                <SkipPrevious />
-              </IconButton>
+              <Tooltip title="Shuffle" placement = "top">
+                <IconButton color={isShuffle ? 'primary' : 'inherit'} onClick={handleShuffle}>
+                  <Shuffle />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Previous" placement = "top">
+                <IconButton color="inherit">
+                  <SkipPrevious />
+                </IconButton>
+              </Tooltip>
             </>
           )}
-          <IconButton color="inherit" onClick={handlePlayPause}>
-            {isPlaying ? <Pause /> : <PlayArrow />}
-          </IconButton>
+          <Tooltip title={isPlaying ? 'Pause' : 'Play'} placement = "top">
+            <IconButton color="inherit" onClick={handlePlayPause}>
+              {isPlaying ? <Pause /> : <PlayArrow />}
+            </IconButton>
+          </Tooltip>
           {isExpanded && (
             <>
-              <IconButton color="inherit">
-                <SkipNext />
-              </IconButton>
-              <IconButton color={isRepeat ? 'primary' : 'inherit'} onClick={handleRepeat}>
-                <Repeat />
-              </IconButton>
+              <Tooltip title="Next" placement = "top">
+                <IconButton color="inherit">
+                  <SkipNext />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Repeat" placement = "top">
+                <IconButton color={isRepeat ? 'primary' : 'inherit'} onClick={handleRepeat}>
+                  <Repeat />
+                </IconButton>
+              </Tooltip>
             </>
           )}
         </Box>

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Toolbar, AppBar, IconButton, Typography, Slider, Box, LinearProgress, Avatar } from '@mui/material';
+import { Toolbar, AppBar, IconButton, Typography, Slider, Box, Avatar } from '@mui/material';
 import { 
   PlayArrow, 
   Pause, 
@@ -172,18 +172,6 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
       </Toolbar>
 
       {/* Progress Bar */}
-      {/* {isExpanded && (
-        <Box sx={{ width: '50%', padding: '0 16px' }}>
-          <AudioProgressTracker
-            audioData={audioData}
-            isPlaying={isPlaying}
-            isLooping={isRepeat}
-            isExpanded={isExpanded}
-            onPlayStateChange={handlePlayEnd}
-          />
-        </Box>
-      )}  */}
-
       <Box sx={{ width: '50%', padding: '0 16px' }}>
         <AudioProgressTracker
           audioData={audioData}

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -9,7 +9,7 @@ import {
   Shuffle, 
   Repeat,
   ExpandLess,
-  ExpandMore
+  ExpandMore,
 } from '@mui/icons-material';
 import AudioProgressTracker from './AudioProgressBar';
 
@@ -21,7 +21,7 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
   const [isShuffle, setIsShuffle] = useState(false);
   const [isRepeat, setIsRepeat] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [volume, setVolume] = useState(30);
+  const [volume, setVolume] = useState(100);
   const [isExpanded, setIsExpanded] = useState(true);
 
   const handleShuffle = () => setIsShuffle((prev) => !prev);
@@ -160,7 +160,10 @@ export default function TonePlayer({ onHeightChange }: TonePlayerProps) {
                 aria-labelledby="volume-slider"
                 min={0}
                 max={100}
-                sx={{ width: 100 }}
+                sx={{
+                  width: 100,
+                  color: 'rgba(0,0,0,0.87)',
+                }}
               />
             </>
           )}

--- a/stresstoneApp/frontend/src/components/TonePlayer.tsx
+++ b/stresstoneApp/frontend/src/components/TonePlayer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Toolbar, AppBar, IconButton, Typography, Slider, Box, LinearProgress, Avatar } from '@mui/material';
+import { Toolbar, AppBar, IconButton, Typography, Slider, Box, Avatar } from '@mui/material';
 import { 
   PlayArrow, 
   Pause, 


### PR DESCRIPTION
Fixed the following issues: 
  1. Music would stop playing when music player was collapsed. 
  2. Volume slider didn't do anything, controls the volume of the music now. 
  3. Progress bar updates much more smoothly. 

Issues to fix: 
  1. Progress bar jumps around slightly when music starts playing either initially or from a paused state. 
  2. Seeking looks incredibly janky when seeking while the music is not paused. 

Features added: 
  1. Music control buttons show tooltips to the user upon hover 
  2. Current time of music is shown on the left of the progress bar with duration on the right. 
<img width="1492" alt="Screenshot 2025-02-26 at 15 36 34" src="https://github.com/user-attachments/assets/56332ad9-f0c5-4b96-a871-c89f448734e4" />

