### PR TITLE
Fixed "No audio available" error message

### DIFF
--- a/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
+++ b/stresstoneApp/frontend/src/components/AudioProgressBar.tsx
@@ -244,13 +244,7 @@ const AudioProgressTracker: React.FC<AudioProgressTrackerProps> = ({
   }
 
   if (!audioData) {
-    return (
-      <Box sx={{ p: 2 }}>
-        <Typography variant="body2" color="text.secondary">
-          No audio available
-        </Typography>
-      </Box>
-    );
+    return; 
   }
 
   return (


### PR DESCRIPTION
Removed the no audio available error message as it was preventing music player from collapsing. 
No track selected is a sufficient error message. 